### PR TITLE
fix 'failed to stabilize' and automation failure

### DIFF
--- a/enableDefaultHostManagement.yml
+++ b/enableDefaultHostManagement.yml
@@ -67,6 +67,7 @@ Resources:
 
   automationServiceRole:
     Type: AWS::IAM::Role
+    DependsOn: managedInstanceRole
     Condition: IsMainRegion
     Properties:
       RoleName: AutomationServiceRole-EnableDefaultSSM
@@ -105,6 +106,7 @@ Resources:
   #-------------------------------------------------
   automationRunbookEnableDefaultSSM:
     Type: AWS::SSM::Document
+    DependsOn: automationServiceRole
     Properties:
       DocumentType: Automation
       Content:
@@ -124,6 +126,7 @@ Resources:
         mainSteps:
           - name: checkExistingServiceSetting
             action: aws:executeAwsApi
+            maxAttempts: 5
             onFailure: Abort
             inputs:
               Service: ssm
@@ -167,6 +170,5 @@ Resources:
     Properties:
       AssociationName: EnableDefaultEC2InstanceManagement
       Name: !Ref automationRunbookEnableDefaultSSM
-      WaitForSuccessTimeoutSeconds: 300
       # Optionally, you can add a schedule to confirm the setting is in place periodically
       #ScheduleExpression: rate(7 days)


### PR DESCRIPTION
*Issue #, if available:*
1. fix 'failed to stabilize' message during the deployment of cloudformation
2. fix state manager association failure by adding "depends on"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
